### PR TITLE
Index tags using string not symbol

### DIFF
--- a/lib/zipkin/encoders/json_encoder.rb
+++ b/lib/zipkin/encoders/json_encoder.rb
@@ -65,7 +65,7 @@ module Zipkin
           Fields::SPAN_ID => span.context.span_id,
           Fields::PARENT_ID => span.context.parent_id,
           Fields::OPERATION_NAME => span.operation_name,
-          Fields::KIND => OT_KIND_TO_ZIPKIN_KIND[span.tags[:'span.kind'] || 'server'],
+          Fields::KIND => OT_KIND_TO_ZIPKIN_KIND[span.tags['span.kind'] || 'server'],
           Fields::TIMESTAMP => start_ts,
           Fields::DURATION => duration,
           Fields::DEBUG => false,


### PR DESCRIPTION
Looks up `span.kind` in the tags index as `'span.kind'` instead of
`:'span.kind'`.

A recent change modified `set_tag` to always store tags internally as
strings instead of symbols.  The leftover symbol-style lookup would
always fail when the new encoding is used.