### PR TITLE
Work around buggy wavefront parsing

### DIFF
--- a/lib/zipkin/encoders/json_encoder.rb
+++ b/lib/zipkin/encoders/json_encoder.rb
@@ -65,7 +65,6 @@ module Zipkin
           Fields::SPAN_ID => span.context.span_id,
           Fields::PARENT_ID => span.context.parent_id,
           Fields::OPERATION_NAME => span.operation_name,
-          Fields::KIND => OT_KIND_TO_ZIPKIN_KIND[span.tags['span.kind'] || 'server'],
           Fields::TIMESTAMP => start_ts,
           Fields::DURATION => duration,
           Fields::DEBUG => false,


### PR DESCRIPTION
Wavefront gets really upset if we send spans with "duplicate" tags.

We can send the span "kind" either as a "span.kind" tag or as part of
the "kind" field in the top-level object.  If we send it in both, then
Wavefront sees this as "duplicate" tags.  This causes problems in their
backend which then caused them to block all our spans.